### PR TITLE
Allow restricting timeout functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ inactivity before being forcibly logged out. It defaults to 900000 (15 minutes).
 in a setInterval to purge all inactive sessions from Meteor. It defaults to
 60000 (1 minute)
 
+`sessionTimeoutQuery` - A MongoDB query object restricting the set of users affected by session timeout functionality with a MongoDB query.
+
 
 How it Works
 ------------

--- a/server/server_timeout.coffee
+++ b/server/server_timeout.coffee
@@ -13,7 +13,9 @@ if Meteor.isServer
 
    interval = Meteor.settings.purgeInterval || 60 * 1000
    Meteor.setInterval(() ->
-      loggedOutUsersIds = _.pluck(Meteor.users.find('services.resume.forceLogout': true).fetch(), '_id')
+      query = Meteor.settings.sessionTimeoutQuery || {}
+      query['services.resume.forceLogout'] = true
+      loggedOutUsersIds = _.pluck(Meteor.users.find(query).fetch(), '_id')
       if loggedOutUsersIds?.length
          Meteor.users.update({_id: {$in: loggedOutUsersIds}},
             {$set: {'services.resume.loginTokens': []},


### PR DESCRIPTION
This allows restricting the timeout functionality to certain user accounts only.
