### PR TITLE
Only remove heartbeat event handler on mousemove

### DIFF
--- a/client/client_timeout.coffee
+++ b/client/client_timeout.coffee
@@ -11,22 +11,23 @@ if Meteor.isClient
       # If it doesn't fire, then the event remains on and we catch
       # the next event that fires.
       ###
+      heartbeat_event_handler = (event) ->
+        #If you move the mouse, we will update your heartbeat, and
+        #remove the event listener so that we don't spam.
+        Meteor.call('session_heartbeat')
+        $(this).off(event)
+ 
       if !session_heartbeat and Meteor.userId()?
          #You're a user, and we haven't started to watch for activity
          session_heartbeat = Meteor.setInterval(() ->
-            $('body').on('mousemove', () ->
-               #If you move the mouse, we will update your heartbeat, and
-               #remove the event listener so that we don't spam.
-               Meteor.call('session_heartbeat')
-               $('body').off('mousemove')
-            )
+            $('body').on('mousemove', heartbeat_event_handler))
          , session_purgeInterval)
       if !Meteor.userId()?
          #Turn off the heartbeat if there's no user any more
          Meteor.clearInterval(session_heartbeat)
          session_heartbeat = null
          #Make sure we're not needlessly looking for mouse events
-         $('body').off('mousemove')
+         $('body').off('mousemove', heartbeat_event_handler)
 
    Deps.autorun () ->
       if Meteor.user()?.services?.resume?.forceLogout


### PR DESCRIPTION
Previously ALL event handlers on 'body' were removed when a heartbeat was
sent to the server. If this was the only event handler then it was no
problem but if other handlers were set up then they would have been
removed as well.
